### PR TITLE
Fix build on macOS

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,6 +33,9 @@ geo = "0.22"
 version = "0.16"
 features = ["extension-module"]
 
+[build-dependencies]
+pyo3-build-config = "0.16"
+
 [dev-dependencies]
 wide = "0.7.4"
 

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,4 @@
+fn main() {
+  pyo3_build_config::add_extension_module_link_args();
+}
+


### PR DESCRIPTION
Add a build.rs to set the appropriate build flags for macOS, following the recommendations here: https://pyo3.rs/v0.16.4/building_and_distribution.html#macos

Relates to https://github.com/insight-platform/Similari/issues/67.